### PR TITLE
equal scaling in ggplot ordination figures

### DIFF
--- a/sfu/workshop2/index.Rmd
+++ b/sfu/workshop2/index.Rmd
@@ -480,7 +480,8 @@ ord_axes <- data.frame(scores(ord))
 ord_spp <- data.frame(scores(ord, display="species"))
 ggplot(ord_axes, aes(NMDS1, NMDS2)) +
   geom_point(shape=21) +
-  geom_point(data=ord_spp, aes(NMDS1, NMDS2), shape=3, colour="red")
+  geom_point(data=ord_spp, aes(NMDS1, NMDS2), shape=3, colour="red") +
+  coord_fixed()
 ```
 
 ---
@@ -491,7 +492,8 @@ ggplot(ord_axes, aes(NMDS1, NMDS2)) +
 ord_spp$spp <- row.names(ord_spp)
 ggplot(ord_axes, aes(NMDS1, NMDS2)) +
   geom_point(shape=21) +
-  geom_text(data=ord_spp, aes(NMDS1, NMDS2, label=spp), colour="red")
+  geom_text(data=ord_spp, aes(NMDS1, NMDS2, label=spp), colour="red") +
+  coord_fixed()
 ```
 
 --- &twocol


### PR DESCRIPTION
All ordinations where the Euclidean distance on the plot reflects/approximates some underling dissimilarity in full dimensions require the axes to be equally scaled. In **ggplot** this is achieved via `coord_fixed()`. This patch implements this.

Also note that this could be done with

```
require(ggvegan) ## install from [github](https://github.com/gavinsimpson/ggvegan)
autoplot(ord)
```

But that might be too large a change to the spirit of the slides.
